### PR TITLE
Disable direct CV generation and S3 update

### DIFF
--- a/academic/views.py
+++ b/academic/views.py
@@ -49,19 +49,12 @@ def index(request):
 
 def generate_cv_pdf(request):
     """
-    Runs the command to generate and upload the CV, then redirects to the 
-    file's public URL.
+    Runs the command to generate and upload the CV, but does not redirect to
+    the file's public URL to avoid serving potentially cached content.
     """
     # Run the management command to generate the CV
     call_command('generate_cv')
-
-    # Get the updated profile object
-    profile = Profile.objects.first()
-
-    # Redirect to the CV's URL, whether it's on S3 or local
-    if profile and profile.cv:
-        return redirect(profile.cv.url)
-    else:
-        # Fallback if the CV doesn't exist for some reason
-        # You can customize this to redirect to the homepage with an error message
-        return redirect('index') 
+    
+    # Intentionally return no content to avoid redirecting to potentially
+    # stale cached files on S3.
+    return HttpResponse(status=204)


### PR DESCRIPTION
Stop redirecting after CV generation to avoid serving stale cached S3 files.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ed90306-0c63-4936-9b71-9b38cc2ae82b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ed90306-0c63-4936-9b71-9b38cc2ae82b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

