### PR TITLE
Add /cv/ slug for the CV

### DIFF
--- a/academic/templates/index.html
+++ b/academic/templates/index.html
@@ -40,7 +40,7 @@
                             <li>
                                 <a href="#footer" class="button bio-button" style="margin-right: 0.7em;">Contact Info</a>
                                 {% if profile.cv %}
-                                    <a href="{{ profile.cv.url }}" class="button bio-button">Download CV</a>
+                                    <a href="{% url 'cv_redirect' %}" class="button bio-button">Download CV</a>
                                 {% endif %}
                             </li>
                         </ul>

--- a/academic/urls.py
+++ b/academic/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("cv/", views.cv_redirect, name="cv_redirect"),
     path("generate_cv/", views.generate_cv_pdf, name="generate_cv_pdf"),
     path('project/<slug:project_slug>/', views.project_view, name='project_view'),
     path('paper/<slug:paper_slug>/', views.paper_redirect, name='paper_redirect'),

--- a/academic/views.py
+++ b/academic/views.py
@@ -59,6 +59,18 @@ def generate_cv_pdf(request):
     # stale cached files on S3.
     return HttpResponse(status=204)
 
+def cv_redirect(request):
+    """
+    Redirects /cv/ to the profile's current CV file, giving the CV a stable,
+    shareable URL (hansriess.com/cv) independent of the underlying storage URL.
+    """
+    profile = Profile.objects.first()
+
+    if profile and profile.cv:
+        return redirect(profile.cv.url)
+
+    raise Http404("CV not found.")
+
 def project_view(request, project_slug):
     grant = get_object_or_404(Grant, slug=project_slug)
     


### PR DESCRIPTION
## Summary
- Add a `cv_redirect` view that redirects to `profile.cv.url`, giving the CV a stable, shareable URL: `hansriess.com/cv`
- Wire up `path("cv/", ...)` in `academic/urls.py`
- Point the "Download CV" button on the homepage at the new `/cv/` slug instead of the raw storage URL

## Test plan
- [ ] Visit `hansriess.com/cv` and confirm it redirects to the current CV PDF
- [ ] Regenerate the CV (`/generate_cv/`) and confirm `/cv/` still resolves to the latest file
- [ ] Click "Download CV" on the homepage and confirm it goes through `/cv/`

---
_Generated by [Claude Code](https://claude.ai/code/session_016CzQt7H9NQDGuuQrcha5Ep)_